### PR TITLE
Add ICD-9 REST API of Keane

### DIFF
--- a/dalisay/app.py
+++ b/dalisay/app.py
@@ -1,0 +1,54 @@
+from flask import Flask
+import os, json, re
+
+def main():
+  app = Flask(__name__)
+  icd_9_file = os.path.join(os.getcwd(), 'diseases.json') # This is meant to be run from the root directory
+  icd_9_json = open(icd_9_file).read()
+
+  icd_9_arr = json.loads(icd_9_json)
+  icd_9_diseases = []
+  icd_9_procedures = []
+
+  for row in icd_9_arr:
+    if row["is_procedure"] == False:
+      icd_9_diseases.append(row)
+    else:
+      icd_9_procedures.append(row)
+
+  @app.route('/')
+  def index():
+    return 'Welcome to the ICD-9 Database! Change address to /disease/[name] or /procedure/[name] to search for a disease or procedure.'
+
+  @app.route('/diseases')
+  def diseases():
+    # Returns a list of all diseases
+    return icd_9_diseases
+
+  @app.route('/disease/<string:name>')
+  def disease(name):
+    # Returns the disease that matches the name
+    for row in icd_9_diseases:
+      disease = re.sub(r"[\(\/ ] ?", "-", re.sub(r"[\_\)\-]", "",row["primary_name"]))
+      if re.search(name, disease, re.IGNORECASE):
+        return row
+    return 'Disease not found.'
+
+  @app.route('/procedures')
+  def procedures():
+    # Returns a list of all procedures
+    return icd_9_procedures
+  
+  @app.route('/procedure/<string:name>')
+  def procedure(name):
+    # Returns the procedure that matches the name
+    for row in icd_9_procedures:
+      procedure = re.sub(r"[\(\/ ] ?", "-", re.sub(r"[\_\)\-]", "",row["primary_name"]))
+      if re.search(name, procedure, re.IGNORECASE):
+        return row
+    return 'Procedure not found.'
+
+  app.run(port=5000)
+
+if __name__ == '__main__':
+    main()

--- a/dalisay/requirements.txt
+++ b/dalisay/requirements.txt
@@ -1,0 +1,7 @@
+blinker==1.9.0
+click==8.1.8
+Flask==3.1.0
+itsdangerous==2.2.0
+Jinja2==3.1.5
+MarkupSafe==3.0.2
+Werkzeug==3.1.3


### PR DESCRIPTION
The **International Classification of Diseases, 9th Revision (ICD-9)** is an international standard to track mortality and morbidity rates within hospitals. Each disease and procedure has its unique ID for the purpose of labeling patient status. 

This **API is designed to retrieve diseases and procedures documented under this standard**. Targeting a specific disease or procedure would need you to enter its partial or full name. 

It **does not support retrievals through ICD codes (9th or 10th revisions) or consumer names**. That can be a future consideration of expanding this API.

The API routes that you can access are:

- `/`, returns a welcome message about the database as a string.
- `/diseases`, returns all documented diseases as an array of objects.
- `/disease/[name]`, returns the closely associated disease as an object.
- `/procedures/`, returns all documented procedures as an array of objects.
- `/procedure/[name]`, returns the closely associated procedure as an object.